### PR TITLE
Adjust Form::Sensible::Reflector and DBIC reflector to allow skipping of fields

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Form::Sensible
 
+NEXT VERSION
+		* Reflector allows skipping fields by leaving them out of the field definition
+
 0.20012 2011-02-01
     * BUGFIX FileSelector problem related to basename usage
     * Addition of 'with_trigger' to options processing in Reflector

--- a/lib/Form/Sensible.pm
+++ b/lib/Form/Sensible.pm
@@ -343,6 +343,8 @@ Luke Saunders - E<lt>luke.saunders@gmail.comE<gt>
 
 Devin Austin - E<lt>dhoss@cpan.orgE<gt>
 
+Alan Rafagudinov - E<lt>alan.rafagudinov@ionzero.comE<gt>
+
 =head1 SPONSORED BY
 
 Ionzero LLC. L<http://ionzero.com/>

--- a/lib/Form/Sensible/Reflector.pm
+++ b/lib/Form/Sensible/Reflector.pm
@@ -114,6 +114,7 @@ sub get_all_field_definitions {
                 delete($additionalfields->{$new_fieldname});
             } else {
                 $field_def = $self->get_field_definition( $form, $handle, $fieldname );
+                next unless defined $field_def;
             }
             $field_def->{name} = $new_fieldname;
             push @allfields, $field_def;


### PR DESCRIPTION
Here's Alan's patch to allow fields to be skipped by the reflectors.
